### PR TITLE
Add static build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04 AS builder
 
+ARG CMAKE_ADDITIONNAL_ARGS
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bison \
@@ -37,7 +39,7 @@ COPY sv_timestamp_logger.* /build/
 
 RUN ls /build && \
   mkdir build && cd build && \
-  cmake -G Ninja .. && \
+  cmake -G Ninja $CMAKE_ADDITIONNAL_ARGS .. && \
   ninja sv_timestamp_logger
 
 FROM ubuntu:24.04

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ Note that the timestamp record file is configurable and that it is also possible
 
 === Get SV parser
 
-sv_timestamp_logger uses [sv_parser](https://github.com/seapath/sv_parser) as a git submodule. The sv_timestamp_logger repository must be cloned with `--recurse-submodules` option.
+sv_timestamp_logger uses https://github.com/seapath/sv_parser[sv_parser] as a git submodule. The sv_timestamp_logger repository must be cloned with `--recurse-submodules` option.
 If you already clone the repository without this submodule, you can launch `git submodule update --init`.
 
 === Build Docker container
@@ -51,7 +51,7 @@ Note: `--cap-add=sys_nice` and `--network=host` option are required respectively
 
 === Usage on SEAPATH
 
-For more information on how to use this tool to test a SEAPATH infrastructure, refer to ["Simulating IEC61850 traffic for Seapath"](https://lf-energy.atlassian.net/wiki/x/RY3lAQ) on the SEAPATH wiki.
+For more information on how to use this tool to test a SEAPATH infrastructure, refer to https://lf-energy.atlassian.net/wiki/x/RY3lAQ[Simulating IEC61850 traffic for Seapath" on the SEAPATH wiki]
 
 === Results
 

--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,40 @@ For example, to build the container for arm64 on a x86 machine, use the command
 docker build --platform linux/arm64 . --tag sv_timestamp_logger_arm64
 ```
 
+=== Static build
+
+A static version of sv_timestamp_logger is available. It requires the following packages :
+- clang
+- cmake
+- libpcap
+- make
+- ninja
+
+You can build the static version with the commands:
+```bash
+cmake -G Ninja -DBUILD_STATIC=ON .
+ninja sv_timestamp_logger
+```
+
+=== Static build with docker
+
+To avoid having to install the dependency, the dockerfile can be used to compile the static version of sv_timestamp_logger:
+```bash
+docker build -t sv_timestamp_logger_static --build-arg CMAKE_ADDITIONNAL_ARGS="-DBUILD_STATIC=ON" .
+```
+
+Once the build is done, you must launch the container to retrieve the static binary and copy it on your machine.
+```bash
+docker run --rm -v $(pwd):$(pwd) --entrypoint "" sv_timestamp_logger_static cp /usr/bin/sv_timestamp_logger $(pwd)/sv_timestamp_logger_static
+```
+
+The binary will be owned by root. You can change the owner to your user with the following command:
+```bash
+chown $USER:$USER sv_timestamp_logger_static
+```
+
+Note: If you are cross compiling from one platform to another, you will need to add the argument `--platform` to the docker run command. This requires the qemu-static package of your distribution to be installed.
+
 == Usage
 
 Launch the docker container with the following command, to get the help message of sv_timestamp_logger.


### PR DESCRIPTION
Add the ability to build sv_timestamp_logger statically allowing it to be run without docker.