### PR TITLE
sv_timestamp_logger.c: fix file closing handling

### DIFF
--- a/sv_timestamp_logger.c
+++ b/sv_timestamp_logger.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
         SV_timestamp_file = fopen(opts.SV_filename, "w");
         if(!SV_timestamp_file) {
                 ret = 2;
-                goto cleanup_SV_file;
+                goto cleanup_monitor;
         }
 
         signal(SIGSTOP, stop_capture_loop);
@@ -250,8 +250,7 @@ int main(int argc, char *argv[]) {
 
         ret = run_monitor(monitor);
 
-cleanup_SV_file:
-        if (opts.SV_filename) fclose(SV_timestamp_file);
+        fclose(SV_timestamp_file);
 
 cleanup_monitor:
         free_monitor(monitor);


### PR DESCRIPTION
If opening opts.SV_filename fails, SV_timestamp_file is NULL. Therefore, it shouldn't goto cleanup_SV_file as the file wasn't opened and fclose on NULL result in a segmentation fault.

Goto label "cleanup_monitor" instead, remove useless label cleanup_SV_file and do not check if opts.SV_filename is NULL as it cannot be the case.