### PR TITLE
.gitmodules: move sv_parser repo link to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/sv_parser"]
 	path = lib/sv_parser
-	url = git@github.com:seapath/sv_parser.git
+	url = https://github.com/seapath/sv_parser/


### PR DESCRIPTION
Using SSH link can introduce issue in some environment where SSH is not configured.