### PR TITLE
sv_timestamp_logger: break after parsing debug option

### DIFF
--- a/sv_timestamp_logger.c
+++ b/sv_timestamp_logger.c
@@ -133,6 +133,7 @@ static int parse_args(int argc, char *argv[])
                         break;
                 case 'g':
                         opts.debug = true;
+                        break;
                 case 'p':
                         opts.clock_device = optarg;
                         break;


### PR DESCRIPTION
Exit switch case statement after parsing debug (-g) option.